### PR TITLE
Bump versions for slbeta3 in master branch 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
     build:
-
         runs-on: ubuntu-latest
-
         steps:
             - uses: actions/checkout@v2
             - name: Ballerina Build
@@ -29,4 +27,5 @@ jobs:
                   args:
                       push
               env:
+                  WORKING_DIR: ./netsuite
                   BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, see [Ballerina Documentation - ballerinax/netsuite](https:
        > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed
        JDK.
  
-2. Download and install [Ballerina Swan Lake Beta2](https://ballerina.io/)
+2. Download and install [Ballerina Swan Lake Beta3](https://ballerina.io/)
  
  
 ### Building the Source

--- a/netsuite/Dependencies.toml
+++ b/netsuite/Dependencies.toml
@@ -1,39 +1,39 @@
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "uuid"
-version = "0.10.0-beta.2"
+version = "0.10.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "xmldata"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "regex"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"

--- a/netsuite/Package.md
+++ b/netsuite/Package.md
@@ -7,7 +7,7 @@ This package provides the capability to access NetSuite and manipulate NetSuite 
 ### Compatibility
 |                               | Version                   |
 |-------------------------------|---------------------------|
-| Ballerina Language            | Swan Lake Beta 2          |
+| Ballerina Language            | Swan Lake Beta 3          |
 | SOAP API                      | SOAP 1.1                  |
 | WSDL                          | 2020.2.0                  |
 


### PR DESCRIPTION
## Purpose
- Bump version to slbeta3 in Dependencies.toml, README.md and Package.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3-SNAPSHOT
