### PR TITLE
Fix Daily build failure [SL Beta3]

### DIFF
--- a/netsuite/commonUtils.bal
+++ b/netsuite/commonUtils.bal
@@ -16,7 +16,6 @@
 
 import ballerina/http;
 import ballerina/lang.'decimal as decimalLib;
-import ballerina/lang.'string as stringLib;
 import ballerina/lang.'boolean as booleanLib;
 import ballerina/time;
 
@@ -29,7 +28,8 @@ isolated function sendRequest(http:Client basicClient, string action, xml payloa
 
 isolated function buildXMLPayloadHeader(NetSuiteConfiguration config) returns string|error {
     time:Utc timeNow = time:utcNow();
-    string timeToSend = stringLib:substring(timeNow.toString(), 0, 10);
+    var [timeInUTC, _] = timeNow;
+    string timeToSend = timeInUTC.toString();
     string uuid = getRandomString();
     string signature = check getNetsuiteSignature(timeToSend, uuid, config);
     string header = string `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" 


### PR DESCRIPTION
## Purpose
> Fixing the daily build all test cases failure in NetSuite beta3 connector
Fixes https://github.com/wso2-enterprise/choreo/issues/7875
## Approach
> This failure has happened due to the output of toString function of time module: Utc type 
Used tuple access to get the values from the Utc type variable

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina Swan Lake Beta3
