### PR TITLE
[SLAlpha5] Add saved search operations

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "netsuite"
-version = "0.9.7"
+version = "0.9.8"
 authors = ["Ballerina"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-netsuite"
 keywords = ["NetSuite", "Finance", "Integration"]

--- a/client.bal
+++ b/client.bal
@@ -230,24 +230,47 @@ public client class Client {
     # if they are valid
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - If success returns a json otherwise the relevant error
+    # + return - If success returns a ballerina stream of customer records otherwise the relevant error
     @display{label: "Search Customers"} 
     isolated remote function searchCustomerRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
-                                                  returns @tainted @display{label: "Response"} stream<Customer, error>|error {
+                                                  returns @tainted @display{label: "Response"} 
+                                                  stream<Customer, error?>|error {
         xml payload = check buildCustomerSearchPayload(self.config, searchElements);
         http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
         return getCustomerSearchResult(response,self.basicClient, self.config);
+    }
+
+    # Perform a saved search search operation using the saved search ID.
+    #
+    # + savedSearchId - Saved search ID
+    # + advancedSearchType - Type of the saved search from the list given here: [CalendarEventSearchAdvanced,
+    # PhoneCallSearchAdvanced, FileSearchAdvanced, FolderSearchAdvanced, NoteSearchAdvanced, MessageSearchAdvanced, 
+    # BinSearchAdvanced, ClassificationSearchAdvanced, DepartmentSearchAdvanced, LocationSearchAdvanced,
+    # SalesTaxItemSearchAdvanced, SubsidiarySearchAdvanced, EmployeeSearchAdvanced, CampaignSearchAdvanced,
+    # ContactSearchAdvanced, CustomerSearchAdvanced, PartnerSearchAdvanced, VendorSearchAdvanced, EntityGroupSearchAdvanced,
+    # JobSearchAdvanced, SiteCategorySearchAdvanced, SupportCaseSearchAdvanced, SolutionSearchAdvanced, TopicSearchAdvanced,
+    # IssueSearchAdvanced,CustomRecordSearchAdvanced, TimeBillSearchAdvanced, BudgetSearchAdvanced, AccountSearchAdvanced,
+    # AccountingTransactionSearchAdvanced, OpportunitySearchAdvanced, TransactionSearchAdvanced, TaskSearchAdvanced,
+    # ItemSearchAdvanced, GiftCertificateSearchAdvanced, PromotionCodeSearchAdvanced,]
+    # + return - If success returns a ballerina stream of json type otherwise the relevant error
+    @display{label: "Perform saved search by ID"}
+    isolated remote function performSavedSearchById(@display{label: "Saved Search ID"} string savedSearchId, 
+                                                    @display{label: "Advanced Search type"} string advancedSearchType) 
+                                                    returns @tainted stream<json, error?>|error {
+        xml payload = check buildSavedSearchByIDPayload(self.config, savedSearchId, advancedSearchType);
+        http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
+        return getSavedSearchResult(response,self.basicClient, self.config);
     }
 
     # Retrieves NetSuite transaction instances from NetSuite according to the given detail 
     # if they are valid
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - If success returns a json otherwise the relevant error
+    # + return - If success returns a ballerina stream of transaction records otherwise the relevant error
     @display{label: "Search Transactions"}
     isolated remote function searchTransactionRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
                                                      returns @tainted @display{label: "Response"} stream<RecordRef, 
-                                                     error>|error {
+                                                     error?>|error {
         xml payload = check buildTransactionSearchPayload(self.config, searchElements);
         http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
         return getTransactionSearchResult(response,self.basicClient, self.config);
@@ -256,11 +279,11 @@ public client class Client {
     # Retrieves NetSuite account record instances from NetSuite according to the given detail 
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - If success returns a account stream otherwise the relevant error
+    # + return - If success returns a ballerina stream of account records otherwise the relevant error
     @display{label: "Search Accounts"}
     isolated remote function searchAccountRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
                                                  returns @tainted @display{label: "Response"} stream<Account, 
-                                                 error>|error {
+                                                 error?>|error {
         xml payload = check buildAccountSearchPayload(self.config, searchElements);
         http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
         return getAccountSearchResult(response, self.basicClient, self.config);
@@ -269,11 +292,11 @@ public client class Client {
     # Retrieves NetSuite contact record instances from NetSuite according to the given detail
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - If success returns a contact stream otherwise the relevant error
+    # + return - If success returns a ballerina stream of contacts records otherwise the relevant error
     @display{label: "Search Contacts"}
     isolated remote function searchContactRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
                                                  returns @tainted @display{label: "Response"} stream<Contact, 
-                                                 error>|error {
+                                                 error?>|error {
         xml payload = check BuildContactSearchPayload(self.config, searchElements);
         http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
         return getContactsSearchResult(response, self.basicClient, self.config);
@@ -282,7 +305,7 @@ public client class Client {
     # Gets a customer record from Netsuite by using internal ID
     #
     # + recordInfo - Ballerina record for Netsuite record information
-    # + return - If success returns a Customer type record otherwise the relevant error
+    # + return - If success returns a customer type record otherwise the relevant error
     @display{label: "Get Customer"}
     isolated remote function getCustomerRecord(@display{label: "Record Detail"} RecordInfo recordInfo) returns 
                                                @tainted @display{label: "Response"} Customer|error {
@@ -378,6 +401,18 @@ public client class Client {
         xml payload = check buildGetServerTime(self.config);
         http:Response response = check sendRequest(self.basicClient, GET_SERVER_TIME_ACTION, payload);
         return getServerTimeResponse(response);
+    }
+
+    # Retrieve a list of existing saved search IDs on a per-record-type basis
+    #
+    # + searchType - Netsuite saved search types
+    # + return - If success returns the list of saved search references otherwise the relevant error
+    @display{label: "Get saved search IDs by record type"} 
+    isolated remote function getSavedSearchIDs(@display{label: "Record type"} string searchType) returns @tainted @display{label: "Response"} 
+                                               SavedSearchResponse|error {
+        xml payload = check BuildSavedSearchRequestPayload(self.config, searchType);
+        http:Response response = check sendRequest(self.basicClient, GET_SAVED_SEARCH_ACTION, payload);
+        return getSavedSearchIDsResponse(response);
     }
  }
 

--- a/commonRecords.bal
+++ b/commonRecords.bal
@@ -45,6 +45,29 @@ public type RecordAddResponse record {
     string warning?;
 };
 
+
+# Netsuite saveSearch list response record
+#
+# + recordRefList - Netsuite record reference list
+# + totalReferences - The total number of records for this search. Depending on the pageSize value, some or all the records may be returned in this response
+# + status - Boolean for checking submission NetSuite failures
+public type SavedSearchResponse record {
+    boolean status;
+    int totalReferences;
+    SavedSearchReference[] recordRefList;
+};
+
+# Saved search reference
+#
+# + internalId - Internal Id of the saved search record
+# + scriptId - ScriptId of the saved search  
+# + name - Name of the Saved search  
+public type SavedSearchReference record {
+    string internalId;
+    string scriptId;
+    string name;
+};
+
 # Ballerina record for Netsuite record deletion response  
 public type RecordDeletionResponse record {
     *RecordAddResponse;
@@ -78,17 +101,6 @@ public type RecordInfo record {
     string recordType;
     @display{label: "Record Internal ID"}
     string recordInternalId;
-};
-
-# Netsuite saveSearch list response record
-#
-# + recordRefList - Netsuite record reference list
-# + numberOfRecords - Number of records  
-# + isSuccess - Boolean for checking submission NetSuite failures
-public type SavedSearchResponse record {
-    int numberOfRecords?;
-    boolean isSuccess;
-    RecordRef[] recordRefList = [];
 };
 
 # RecordType Connector supports for creation operation for now.  
@@ -132,7 +144,16 @@ public type SearchElement record {
 };
 
 type SearchResultStatus record {
+    *CommonSearchResult;
     xml recordList;
+};
+
+type SavedSearchResult record {
+    *CommonSearchResult;
+    json[] recordList;
+};
+
+type CommonSearchResult record {
     int pageIndex;
     int totalPages;
     string searchId;

--- a/commonUtils.bal
+++ b/commonUtils.bal
@@ -125,15 +125,16 @@ isolated function buildDeletePayload(RecordDetail recordType, NetSuiteConfigurat
     return getSoapPayload(header, body);
 }
 
-isolated function buildUpdateRecord(ExistingRecordType recordType, RecordCoreType recordCoreType, NetSuiteConfiguration config) 
-                                    returns xml|error {
+isolated function buildUpdateRecord(ExistingRecordType recordType, RecordCoreType recordCoreType, NetSuiteConfiguration 
+                                    config) returns xml|error {
     string header = check buildXMLPayloadHeader(config);
     string elements = check getUpdateOperationElements(recordType, recordCoreType);
     string body = getUpdateXMLBodyWithParentElement(elements);
     return getSoapPayload(header, body);    
 }
 
-isolated function getUpdateOperationElements(ExistingRecordType recordType, RecordCoreType recordCoreType) returns string|error {
+isolated function getUpdateOperationElements(ExistingRecordType recordType, RecordCoreType recordCoreType) returns 
+                                             string|error {
     string subElements = EMPTY_STRING;   
     match recordCoreType {
         CUSTOMER => {
@@ -251,16 +252,27 @@ isolated function buildGetAllPayload(string recordType, NetSuiteConfiguration co
 
 isolated function getXMLBodyForGetAllOperation(string recordType) returns string{
     return string `<soapenv:Body><urn:getAll><record recordType="${recordType}"/></urn:getAll></soapenv:Body>
-    </soapenv:Envelope>`;
+        </soapenv:Envelope>`;
 }
 
 isolated function getXMLBodyForGetServerTime() returns string{
     return string`<soapenv:Body><urn:getServerTime/></soapenv:Body></soapenv:Envelope>`;
 }
 
+isolated function getXMLBodyForGetSavedSearchIDs(string searchType) returns string{
+    return string `<soapenv:Body><urn:getSavedSearch><record searchType="${searchType}"/></urn:getSavedSearch>
+        </soapenv:Body></soapenv:Envelope>`;
+}
+
 isolated function buildGetServerTime(NetSuiteConfiguration config) returns xml|error {
     string header = check buildXMLPayloadHeader(config);
     string body = getXMLBodyForGetServerTime();
+    return getSoapPayload(header, body);
+}
+
+isolated function BuildSavedSearchRequestPayload(NetSuiteConfiguration config, string searchType) returns xml|error {
+    string header = check buildXMLPayloadHeader(config);
+    string body = getXMLBodyForGetSavedSearchIDs(searchType);
     return getSoapPayload(header, body);
 }
 

--- a/constants.bal
+++ b/constants.bal
@@ -25,12 +25,14 @@ const string & readonly GET_SAVED_SEARCH_SOAP_ACTION = "getSavedSearch";
 const string & readonly SOAP_ACTION_HEADER = "SOAPAction";
 const string & readonly GET_SERVER_TIME_ACTION = "getServerTime";
 const string & readonly SEARCH_MORE_WITH_ID = "searchMoreWithId";
+const string & readonly GET_SAVED_SEARCH_ACTION = "getSavedSearch";
 
 //Error Messages
 const string & readonly UNKNOWN_TYPE = "Unknown record type provided!";
 const string & readonly NO_RECORD_FOUND = "No record found!";
 const string & readonly NO_RECORD_CHECK = "No record found, Check the record detail!";
-const string & readonly NOT_SUCCESS = "Sorry, Search was not successful in Netsuite!";
+const string & readonly NOT_SUCCESS = "Searching was not successful in Netsuite!";
+const string NO_TYPE_MATCHED = "No any advanced search type matched with the provided type.";
 
 //String Replacements
 const string & readonly MESSAGES_NS = "xmlns=\"urn:messages_2020_2.platform.webservices.netsuite.com\"";
@@ -60,3 +62,17 @@ const string & readonly REQUEST_NEXT_PAGE = "Requesting the next page!";
 
 //Netsuite SOAP endpoint
 const string & readonly NETSUITE_ENDPOINT = "/services/NetSuitePort_2020_2";
+
+//XSDNameSpaces
+const string SCHEDULING_2020_2 = "urn:scheduling_2020_2.activities.webservices.netsuite.com";
+const string FILE_CABINET_2020_2 = "urn:filecabinet_2020_2.documents.webservices.netsuite.com";
+const string COMMUNICATION_2020_2 = "urn:urn:communication_2020_2.general.webservices.netsuite.com";
+const string ACCOUNTING_2020_2 = "urn:accounting_2020_2.lists.webservices.netsuite.com";
+const string EMPLOYEES_2020_2 = "urn:employees_2020_2.lists.webservices.netsuite.com";
+const string MARKETING_2020_2 = "urn:marketing_2020_2.lists.webservices.netsuite.com";
+const string RELATIONSHIPS_2020_2 = "urn:relationships_2020_2.lists.webservices.netsuite.com";
+const string WEBSITE_2020_2 = "urn:website_2020_2.lists.webservices.netsuite.com";
+const string SUPPORT_2020_2 = "urn:support_2020_2.lists.webservices.netsuite.com";
+const string CUSTOMIZATION_2020_2 = "urn:customization_2020_2.setup.webservices.netsuite.com";
+const string FINANCIAL_2020_2 = "urn:financial_2020_2.transactions.webservices.netsuite.com";
+const string SALES_2020_2 = "urn:sales_2020_2.transactions.webservices.netsuite.com";

--- a/customer.bal
+++ b/customer.bal
@@ -148,7 +148,7 @@ isolated function getCustomerSearchRequestBody(SearchElement[] searchElements) r
     </urn:searchRecord></urn:search></soapenv:Body></soapenv:Envelope>`;
 }
 
-isolated function buildCustomerSearchPayload(NetSuiteConfiguration config,SearchElement[] searchElement) returns 
+isolated function buildCustomerSearchPayload(NetSuiteConfiguration config, SearchElement[] searchElement) returns 
                                             xml|error {
     string requestHeader = check buildXMLPayloadHeader(config);
     string requestBody = getCustomerSearchRequestBody(searchElement);

--- a/enums.bal
+++ b/enums.bal
@@ -14,6 +14,45 @@
 // specific language governing permissions and limitations
 // under the License.
 
+public enum AdvancedSearchTypes {
+        CALENDAR_EVENT_SEARCH_ADVANCED = "CalendarEventSearchAdvanced",
+        TASK_SEARCH_ADVANCED = "TaskSearchAdvanced",
+        PHONE_CALL_SEARCH_ADVANCED = "PhoneCallSearchAdvanced",
+        FILE_SEARCH_ADVANCED = "FileSearchAdvanced",
+        FOLDER_SEARCH_ADVANCED = "FolderSearchAdvanced",
+        NOTE_SEARCH_ADVANCED = "NoteSearchAdvanced",
+        MESSAGE_SEARCH_ADVANCED = "MessageSearchAdvanced",
+        ITEM_SEARCH_ADVANCED = "ItemSearchAdvanced",
+        ACCOUNT_SEARCH_ADVANCED = "AccountSearchAdvanced",
+        BIN_SEARCH_ADVANCED = "BinSearchAdvanced",
+        CLASSIFICATION_SEARCH_ADVANCED = "ClassificationSearchAdvanced",
+        DEPARTMENT_SEARCH_ADVANCED = "DepartmentSearchAdvanced",
+        LOCATION_SEARCH_ADVANCED = "LocationSearchAdvanced",
+        GIFT_CERTIFICATE_SEARCH_ADVANCED = "GiftCertificateSearchAdvanced",
+        SALES_TAX_ITEM_SEARCH_ADVANCED = "SalesTaxItemSearchAdvanced",
+        SUBSIDIARY_SEARCH_ADVANCED = "SubsidiarySearchAdvanced",
+        EMPLOYEE_SEARCH_ADVANCED = "EmployeeSearchAdvanced",
+        CAMPAIGN_SEARCH_ADVANCED = "CampaignSearchAdvanced",
+        PROMOTION_CODE_SEARCH_ADVANCED = "PromotionCodeSearchAdvanced",
+        CONTACT_SEARCH_ADVANCED = "ContactSearchAdvanced",
+        CUSTOMER_SEARCH_ADVANCED = "CustomerSearchAdvanced",
+        PARTNER_SEARCH_ADVANCED = "PartnerSearchAdvanced",
+        VENDOR_SEARCH_ADVANCED = "VendorSearchAdvanced",
+        ENTITY_GROUP_SEARCH_ADVANCED = "EntityGroupSearchAdvanced",
+        JOB_SEARCH_ADVANCED = "JobSearchAdvanced",
+        SITE_CATEGORY_SEARCH_ADVANCED = "SiteCategorySearchAdvanced",
+        SUPPORT_CASE_SEARCH_ADVANCED = "SupportCaseSearchAdvanced",
+        SOLUTION_SEARCH_ADVANCED = "SolutionSearchAdvanced",
+        TOPIC_SEARCH_ADVANCED = "TopicSearchAdvanced",
+        ISSUE_SEARCH_ADVANCED = "IssueSearchAdvanced",
+        CUSTOM_RECORD_SEARCH_ADVANCED = "CustomRecordSearchAdvanced",
+        TIME_BILL_SEARCH_ADVANCED = "TimeBillSearchAdvanced",
+        BUDGET_SEARCH_ADVANCED = "BudgetSearchAdvanced",
+        ACCOUNTING_TRANSACTION_SEARCH_ADVANCED = "AccountingTransactionSearchAdvanced",
+        OPPORTUNITY_SEARCH_ADVANCED = "OpportunitySearchAdvanced",
+        TRANSACTION_SEARCH_ADVANCED = "TransactionSearchAdvanced"
+}
+
 public enum TransactionType {
     TRANS_ASSEMBLY_BUILD = "_assemblyBuild",
     TRANS_ASSEMBLY_UNBUILD = "_assemblyUnbuild",

--- a/searchUtils.bal
+++ b/searchUtils.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/lang.'xml as xmlLib;
+import ballerina/http;
 
 isolated  function getSearchElement(SearchElement[] searchElements) returns string{
     string searchElementInPayloadBody = EMPTY_STRING;
@@ -75,4 +76,145 @@ isolated function buildSearchMoreWithIdPayload(NetSuiteConfiguration config, int
     string requestHeader = check buildXMLPayloadHeader(config);
     string requestBody = getNextPageRequestElement(pageIndex, searchId);
     return check getSoapPayload(requestHeader, requestBody); 
+}
+
+isolated function buildSavedSearchByIDPayload(NetSuiteConfiguration config, string savedSearchID, string advancedSearchType) returns xml|error {
+    string requestHeader = check buildXMLPayloadHeader(config);
+    string requestBody = check getSaveSearchByIDRequestBody(savedSearchID, advancedSearchType);
+    return check getSoapPayload(requestHeader, requestBody);
+}
+
+isolated function getSaveSearchByIDRequestBody(string savedSearchID, string advancedSearchType) returns string|error {
+    return string `<soapenv:Body><urn:search xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <urn:searchRecord xmlns:q1="${check getSearchAdvancedNS(advancedSearchType)}"
+        xsi:type="q1:${advancedSearchType}" savedSearchId="${savedSearchID}" />
+        </urn:search></soapenv:Body></soapenv:Envelope>`;
+}
+
+isolated function getSavedSearchResult(http:Response response, http:Client httpClient, NetSuiteConfiguration config) returns stream<json, error>|error {
+    SavedSearchResult resultStatus = check getXMLRecordListFromSavedSearchResult(response);
+    SavedSearchStream instance = check new (httpClient,resultStatus,config);
+    stream<json, error> finalStream = new (instance);
+    return finalStream;
+}
+
+isolated function getSavedSearchNextPageResult(http:Response response) returns @tainted record {|json[] savedSearchRows; SavedSearchResult status;|}|error {
+    SavedSearchResult resultStatus = check getXMLRecordListFromSavedSearchResult(response);
+    return {savedSearchRows : resultStatus.recordList, status: resultStatus};
+}
+
+isolated function getSearchAdvancedNS(string searchAdvanceType) returns string|error {
+    match searchAdvanceType {
+        CALENDAR_EVENT_SEARCH_ADVANCED => {
+            return SCHEDULING_2020_2;
+        }
+        TASK_SEARCH_ADVANCED => {
+            return SCHEDULING_2020_2;
+        }
+        PHONE_CALL_SEARCH_ADVANCED => {
+            return SCHEDULING_2020_2;
+        }
+        FILE_SEARCH_ADVANCED => {
+            return FILE_CABINET_2020_2;
+        }
+        FOLDER_SEARCH_ADVANCED => {
+            return FILE_CABINET_2020_2;
+        }
+        NOTE_SEARCH_ADVANCED => {
+            return COMMUNICATION_2020_2;
+        }
+        MESSAGE_SEARCH_ADVANCED => {
+            return COMMUNICATION_2020_2;
+        }
+        ITEM_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        ACCOUNT_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        BIN_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        CLASSIFICATION_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        DEPARTMENT_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        LOCATION_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        GIFT_CERTIFICATE_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        SALES_TAX_ITEM_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        SUBSIDIARY_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        EMPLOYEE_SEARCH_ADVANCED => {
+            return EMPLOYEES_2020_2;
+        }
+        CAMPAIGN_SEARCH_ADVANCED => {
+            return MARKETING_2020_2;
+        }
+        PROMOTION_CODE_SEARCH_ADVANCED => {
+            return MARKETING_2020_2;
+        }
+        CONTACT_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        CUSTOMER_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        PARTNER_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        VENDOR_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        ENTITY_GROUP_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        JOB_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        SITE_CATEGORY_SEARCH_ADVANCED => {
+            return WEBSITE_2020_2;
+        }
+        SUPPORT_CASE_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        SOLUTION_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        TOPIC_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        ISSUE_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        CUSTOM_RECORD_SEARCH_ADVANCED => {
+            return CUSTOMIZATION_2020_2;
+        }
+        TIME_BILL_SEARCH_ADVANCED => {
+            return EMPLOYEES_2020_2;
+        }
+        BUDGET_SEARCH_ADVANCED => {
+            return FINANCIAL_2020_2;
+        }
+        ACCOUNTING_TRANSACTION_SEARCH_ADVANCED => {
+            return SALES_2020_2;
+        }
+        OPPORTUNITY_SEARCH_ADVANCED => {
+            return SALES_2020_2;
+        }
+        TRANSACTION_SEARCH_ADVANCED => {
+            return SALES_2020_2;
+        }
+        _ => {
+            fail error(NO_TYPE_MATCHED);
+        }
+    }
 }

--- a/streams.bal
+++ b/streams.bal
@@ -189,3 +189,45 @@ class ContactStream {
         return newPage.contacts;
     }
 }
+
+class SavedSearchStream {
+    private json[] savedSearchRowEntries = [];
+    int index = 0;
+    private final http:Client httpClient;
+    int totalPages;
+    int currentPage;
+    string searchId;
+    NetSuiteConfiguration config;
+
+    isolated function  init(http:Client httpClient, SavedSearchResult resultStatus, NetSuiteConfiguration config) 
+                            returns @tainted error? {
+        self.httpClient = httpClient;
+        self.savedSearchRowEntries = resultStatus.recordList;
+        self.totalPages = resultStatus.totalPages;
+        self.currentPage = resultStatus.pageIndex;
+        self.searchId = resultStatus.searchId;
+        self.config = config;
+    }
+
+    public isolated function next() returns @tainted record {| json value; |}|error? {
+        if(self.index < self.savedSearchRowEntries.length()) {
+            record {| json value; |} singleRecord = {value: self.savedSearchRowEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }else if (self.totalPages != self.currentPage ) {
+            self.index = 0;
+            self.savedSearchRowEntries = check self.fetchNextSavedSearchResults();
+            record {| json value; |} singleRecord = {value: self.savedSearchRowEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchNextSavedSearchResults() returns @tainted json[]|error {
+        xml payload = check buildSearchMoreWithIdPayload(self.config, self.currentPage + 1, self.searchId);
+        http:Response response = check sendRequest(self.httpClient, SEARCH_MORE_WITH_ID, payload);
+        record {|json[] savedSearchRows; SavedSearchResult status;|} newPage = check getSavedSearchNextPageResult(response);
+        self.currentPage=newPage.status.pageIndex;
+        return newPage.savedSearchRows;
+    }
+}

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -487,7 +487,7 @@ function testCustomerSearchOperation() {
     SearchElement[] searchData = [];
     searchData.push(searchRecord);
     var output = netsuiteClient->searchCustomerRecords(searchData);
-    if (output is stream<Customer, error>) {
+    if (output is stream<Customer, error?>) {
         int index = 0;
         error? e = output.forEach(function (Customer queryResult) {
             index = index + 1;
@@ -509,7 +509,7 @@ function testAccountSearchOperation() {
     };
     SearchElement[] searchElements = [searchRecord];
     var output = netsuiteClient->searchAccountRecords(searchElements);
-     if (output is stream<Account, error>) {
+     if (output is stream<Account, error?>) {
         int index = 0;
         error? e = output.forEach(function (Account account) {
             index = index + 1;
@@ -531,7 +531,7 @@ function testContactSearchOperation() {
     };
     SearchElement[] searchElements = [searchRecord];
     var output = netsuiteClient->searchContactRecords(searchElements);
-     if (output is stream<Contact, error>) {
+     if (output is stream<Contact, error?>) {
         int index = 0;
         error? e = output.forEach(function (Contact contact) {
             index = index + 1;
@@ -549,8 +549,8 @@ function testTransactionSearchOperation() {
         fieldName: "amount",
         searchType: SEARCH_DOUBLE_FIELD,
         operator: "between",
-        value1: "100000",
-        value2: "2000000"
+        value1: "150000",
+        value2: "200000"
     };
 
     SearchElement searchRecord3 = {
@@ -569,9 +569,9 @@ function testTransactionSearchOperation() {
         value1 : "2021-01-23T10:20:15",
         value2 : "2021-03-23T10:20:15"
     };
-    SearchElement[] searchElements = [searchRecord2];
+    SearchElement[] searchElements = [searchRecord1];
     var output = netsuiteClient->searchTransactionRecords(searchElements);
-     if (output is stream<RecordRef, error>) {
+    if (output is stream<RecordRef, error?>) {
         int index = 0;
         error? e = output.forEach(function (RecordRef recordRef) {
             index = index + 1;
@@ -707,6 +707,37 @@ function testGetServerTime() {
         log:printInfo(output.toString());
     } else {
         test:assertFalse(true, output.toString());
+    }
+}
+
+string savedSearchID = "";
+@test:Config {enable: true}
+function testGetSavedSearchIds() {
+    log:printInfo("testGetSavedSearchIds");
+    SavedSearchResponse|error output = netsuiteClient->getSavedSearchIDs("vendor");
+    if (output is SavedSearchResponse) {
+        savedSearchID = output.recordRefList[0].internalId;
+    } else {
+        test:assertFalse(true, output.toString());
+    }
+}
+
+
+@test:Config {enable: true, dependsOn: [testGetSavedSearchIds]}
+function testPerformSavedSearchById() {
+    log:printInfo("testPerformSavedSearchById");
+    var output = netsuiteClient->performSavedSearchById(savedSearchID, "VendorSearchAdvanced");
+    if (output is stream<json, error?>) {
+        int index = 0;
+        error? e = output.forEach(function (json queryResult) {
+            index = index + 1;
+            if(index == 0) {
+                log:printInfo(queryResult.toString());
+            }
+        });
+        log:printInfo("Total count of records in SavedSearchResults : " +  index.toString()); 
+    } else {
+         test:assertFalse(true, output.toString());
     }
 }
 


### PR DESCRIPTION
## Purpose
> Add saved search operations to the connector.
Fixes https://github.com/wso2-enterprise/choreo/issues/7788

## Goals
> Improve the connector based on feature requests

## Approach
1. Added getSavedSearchIDs operation
2. Added performSavedSearchById operation with stream support.
3. Updated docs

## Automation tests
 - Unit tests 
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina Swan Lake Alpha5

## Learning
> https://www.netsuite.com/portal/developers/resources/suitetalk-documentation.shtml