### PR TITLE
[SL Beta3] Add saved search operation

### DIFF
--- a/netsuite/client.bal
+++ b/netsuite/client.bal
@@ -236,14 +236,50 @@ public isolated client class Client {
         }  
     }
 
+    # Retrieve a list of existing saved search IDs on a per-record-type basis
+    #
+    # + searchType - Netsuite saved search types
+    # + return - If success returns the list of saved search references otherwise the relevant error
+    @display{label: "Get saved search IDs by record type"} 
+    isolated remote function getSavedSearchIDs(@display{label: "Record type"} string searchType) returns @tainted @display{label: "Response"} 
+                                               SavedSearchResponse|error {
+        xml payload = check BuildSavedSearchRequestPayload(self.config, searchType);
+        http:Response response = check sendRequest(self.basicClient, GET_SAVED_SEARCH_ACTION, payload);
+        return getSavedSearchIDsResponse(response);
+    }
+ 
+    # Perform a saved search search operation using the saved search ID.
+    #
+    # + savedSearchId - Saved search ID (Internal ID)
+    # + advancedSearchType - Type of the saved search from the list given here: [CalendarEventSearchAdvanced,
+    # PhoneCallSearchAdvanced, FileSearchAdvanced, FolderSearchAdvanced, NoteSearchAdvanced, MessageSearchAdvanced, 
+    # BinSearchAdvanced, ClassificationSearchAdvanced, DepartmentSearchAdvanced, LocationSearchAdvanced,
+    # SalesTaxItemSearchAdvanced, SubsidiarySearchAdvanced, EmployeeSearchAdvanced, CampaignSearchAdvanced,
+    # ContactSearchAdvanced, CustomerSearchAdvanced, PartnerSearchAdvanced, VendorSearchAdvanced, EntityGroupSearchAdvanced,
+    # JobSearchAdvanced, SiteCategorySearchAdvanced, SupportCaseSearchAdvanced, SolutionSearchAdvanced, TopicSearchAdvanced,
+    # IssueSearchAdvanced,CustomRecordSearchAdvanced, TimeBillSearchAdvanced, BudgetSearchAdvanced, AccountSearchAdvanced,
+    # AccountingTransactionSearchAdvanced, OpportunitySearchAdvanced, TransactionSearchAdvanced, TaskSearchAdvanced,
+    # ItemSearchAdvanced, GiftCertificateSearchAdvanced, PromotionCodeSearchAdvanced,]
+    # + return - Ballerina stream of json type otherwise the relevant error
+    @display{label: "Perform saved search by ID"}
+    isolated remote function performSavedSearchById(@display{label: "Saved Search ID"} string savedSearchId, 
+                                                    @display{label: "Advanced Search type"} string advancedSearchType) returns 
+                                                    @tainted stream<json, error?>|error {
+        xml payload = check buildSavedSearchByIDPayload(self.config, savedSearchId, advancedSearchType);
+        http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
+        return getSavedSearchResult(response, self.basicClient, self.config);
+    }
+
+
     # Retrieves NetSuite client instances from NetSuite according to the given detail 
     # if they are valid.
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - json otherwise the relevant error
+    # + return - Ballerina stream of customer type records otherwise the relevant error
     @display{label: "Search Customers"} 
     isolated remote function searchCustomerRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
-                                                  returns @tainted @display{label: "Response"} stream<Customer, error?>|error {
+                                                  returns @tainted @display{label: "Response"} 
+                                                  stream<Customer, error?>|error {
         xml payload = check buildCustomerSearchPayload(self.config, searchElements);
         http:Response response = check sendRequest(self.basicClient, SEARCH_SOAP_ACTION, payload);
         return getCustomerSearchResult(response,self.basicClient, self.config);
@@ -253,7 +289,7 @@ public isolated client class Client {
     # if they are valid.
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - json otherwise the relevant error
+    # + return -  Ballerina stream of transaction type records otherwise the relevant error
     @display{label: "Search Transactions"}
     isolated remote function searchTransactionRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
                                                      returns @tainted @display{label: "Response"} stream<RecordRef, 
@@ -266,7 +302,7 @@ public isolated client class Client {
     # Retrieves NetSuite account record instances from NetSuite according to the given detail.
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - account stream otherwise the relevant error
+    # + return - Ballerina stream of account type records otherwise the relevant error
     @display{label: "Search Accounts"}
     isolated remote function searchAccountRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
                                                  returns @tainted @display{label: "Response"} stream<Account, 
@@ -279,7 +315,7 @@ public isolated client class Client {
     # Retrieves NetSuite contact record instances from NetSuite according to the given detail
     #
     # + searchElements - Details of a NetSuite record to be retrieved from NetSuite
-    # + return - contact stream otherwise the relevant error
+    # + return - Ballerina stream of contact type records otherwise the relevant error
     @display{label: "Search Contacts"}
     isolated remote function searchContactRecords(@display{label: "Search Elements"} SearchElement[] searchElements) 
                                                  returns @tainted @display{label: "Response"} stream<Contact, 

--- a/netsuite/commonRecords.bal
+++ b/netsuite/commonRecords.bal
@@ -45,6 +45,30 @@ public type RecordAddResponse record {
     string warning?;
 };
 
+
+# Netsuite saveSearch list response record
+#
+# + recordRefList - Netsuite record reference list
+# + totalReferences - The total number of records for this search. Depending on the pageSize value, some or all the 
+# records may be returned in this response
+# + status - Boolean for checking submission NetSuite failures
+public type SavedSearchResponse record {
+    boolean status;
+    int totalReferences;
+    SavedSearchReference[] recordRefList;
+};
+
+# Saved search reference
+#
+# + internalId - Internal Id of the saved search record
+# + scriptId - ScriptId of the saved search  
+# + name - Name of the Saved search  
+public type SavedSearchReference record {
+    string internalId;
+    string scriptId;
+    string name;
+};
+
 # Ballerina record for Netsuite record deletion response  
 public type RecordDeletionResponse record {
     *RecordAddResponse;
@@ -78,17 +102,6 @@ public type RecordInfo record {
     string recordType;
     @display{label: "Record Internal ID"}
     string recordInternalId;
-};
-
-# Netsuite saveSearch list response record
-#
-# + recordRefList - Netsuite record reference list
-# + numberOfRecords - Number of records  
-# + isSuccess - Boolean for checking submission NetSuite failures
-public type SavedSearchResponse record {
-    int numberOfRecords?;
-    boolean isSuccess;
-    RecordRef[] recordRefList = [];
 };
 
 # RecordType Connector supports for creation operation for now.  
@@ -132,7 +145,16 @@ public type SearchElement record {
 };
 
 type SearchResultStatus record {
+    *CommonSearchResult;
     xml recordList;
+};
+
+type SavedSearchResult record {
+    *CommonSearchResult;
+    json[] recordList;
+};
+
+type CommonSearchResult record {
     int pageIndex;
     int totalPages;
     string searchId;

--- a/netsuite/commonUtils.bal
+++ b/netsuite/commonUtils.bal
@@ -125,15 +125,16 @@ isolated function buildDeletePayload(RecordDetail recordType, NetSuiteConfigurat
     return getSoapPayload(header, body);
 }
 
-isolated function buildUpdateRecord(ExistingRecordType recordType, RecordCoreType recordCoreType, NetSuiteConfiguration config) 
-                                    returns xml|error {
+isolated function buildUpdateRecord(ExistingRecordType recordType, RecordCoreType recordCoreType, NetSuiteConfiguration 
+                                    config) returns xml|error {
     string header = check buildXMLPayloadHeader(config);
     string elements = check getUpdateOperationElements(recordType, recordCoreType);
     string body = getUpdateXMLBodyWithParentElement(elements);
     return getSoapPayload(header, body);    
 }
 
-isolated function getUpdateOperationElements(ExistingRecordType recordType, RecordCoreType recordCoreType) returns string|error {
+isolated function getUpdateOperationElements(ExistingRecordType recordType, RecordCoreType recordCoreType) returns 
+                                             string|error {
     string subElements = EMPTY_STRING;   
     match recordCoreType {
         CUSTOMER => {
@@ -211,13 +212,13 @@ isolated function buildGetOperationPayload(RecordInfo records, NetSuiteConfigura
     string header = check buildXMLPayloadHeader(config);
     string elements = prepareElementsForGetOperation(records);
     string body = string `<soapenv:Body><urn:get xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">${elements}
-    </urn:get></soapenv:Body></soapenv:Envelope>`;
+        </urn:get></soapenv:Body></soapenv:Envelope>`;
     return getSoapPayload(header, body);
 }
 
 isolated function prepareElementsForGetOperation(RecordInfo recordDetail) returns string {
     string elements = string `<urn:baseRef internalId="${recordDetail.recordInternalId}" type="${recordDetail.recordType}"
-    xsi:type="urn1:RecordRef"/>`;
+        xsi:type="urn1:RecordRef"/>`;
     return elements;
 }
 
@@ -231,7 +232,7 @@ isolated function getDeletePayload(RecordDetail recordDetail) returns string{
 
 isolated function getXMLElementForDeletion(RecordDetail recordDetail) returns string {
     return string `<urn:baseRef type="${recordDetail.recordType}" internalId="${recordDetail.recordInternalId}" 
-    xsi:type="urn1:RecordRef"/>`;
+        xsi:type="urn1:RecordRef"/>`;
 }
 
 isolated function getXMLElementForDeletionWithDeleteReason(RecordDetail recordDetail) returns string {
@@ -251,7 +252,7 @@ isolated function buildGetAllPayload(string recordType, NetSuiteConfiguration co
 
 isolated function getXMLBodyForGetAllOperation(string recordType) returns string{
     return string `<soapenv:Body><urn:getAll><record recordType="${recordType}"/></urn:getAll></soapenv:Body>
-    </soapenv:Envelope>`;
+        </soapenv:Envelope>`;
 }
 
 isolated function getXMLBodyForGetServerTime() returns string{
@@ -332,4 +333,15 @@ isolated function extractRecordRefFromXML(xml element) returns RecordRef {
 
 isolated function extractRecordInternalIdFromXMLAttribute(xml element) returns string {
     return let var internalId = element.internalId in internalId is error ? EMPTY_STRING : internalId;
+}
+
+isolated function BuildSavedSearchRequestPayload(NetSuiteConfiguration config, string searchType) returns xml|error {
+    string header = check buildXMLPayloadHeader(config);
+    string body = getXMLBodyForGetSavedSearchIDs(searchType);
+    return getSoapPayload(header, body);
+}
+
+isolated function getXMLBodyForGetSavedSearchIDs(string searchType) returns string{
+    return string `<soapenv:Body><urn:getSavedSearch><record searchType="${searchType}"/></urn:getSavedSearch>
+        </soapenv:Body></soapenv:Envelope>`;
 }

--- a/netsuite/constants.bal
+++ b/netsuite/constants.bal
@@ -15,48 +15,64 @@
 // under the License.
 
 //SOAP Actions
-const string & readonly ADD_SOAP_ACTION = "add";
-const string & readonly DELETE_SOAP_ACTION = "delete";
-const string & readonly UPDATE_SOAP_ACTION = "update";
-const string & readonly GET_ALL_SOAP_ACTION = "getAll";
-const string & readonly SEARCH_SOAP_ACTION = "search";
-const string & readonly GET_SOAP_ACTION = "get";
-const string & readonly GET_SAVED_SEARCH_SOAP_ACTION = "getSavedSearch";
-const string & readonly SOAP_ACTION_HEADER = "SOAPAction";
-const string & readonly GET_SERVER_TIME_ACTION = "getServerTime";
-const string & readonly SEARCH_MORE_WITH_ID = "searchMoreWithId";
+const string ADD_SOAP_ACTION = "add";
+const string DELETE_SOAP_ACTION = "delete";
+const string UPDATE_SOAP_ACTION = "update";
+const string GET_ALL_SOAP_ACTION = "getAll";
+const string SEARCH_SOAP_ACTION = "search";
+const string GET_SOAP_ACTION = "get";
+const string GET_SAVED_SEARCH_SOAP_ACTION = "getSavedSearch";
+const string SOAP_ACTION_HEADER = "SOAPAction";
+const string GET_SERVER_TIME_ACTION = "getServerTime";
+const string SEARCH_MORE_WITH_ID = "searchMoreWithId";
+const string GET_SAVED_SEARCH_ACTION = "getSavedSearch";
 
 //Error Messages
-const string & readonly UNKNOWN_TYPE = "Unknown record type provided!";
-const string & readonly NO_RECORD_FOUND = "No record found!";
-const string & readonly NO_RECORD_CHECK = "No record found, Check the record detail!";
-const string & readonly NOT_SUCCESS = "Sorry, Search was not successful in Netsuite!";
+const string UNKNOWN_TYPE = "Unknown record type provided!";
+const string NO_RECORD_FOUND = "No record found!";
+const string NO_RECORD_CHECK = "No record found, Check the record detail!";
+const string NOT_SUCCESS = "Searching was not successful in Netsuite!";
+const string NO_TYPE_MATCHED = "No any advanced search type matched with the provided type.";
 
 //String Replacements
-const string & readonly MESSAGES_NS = "xmlns=\"urn:messages_2020_2.platform.webservices.netsuite.com\"";
-const string & readonly CORE_NS = "xmlns:platformCore=\"urn:core_2020_2.platform.webservices.netsuite.com\"";
-const string & readonly XSI_NS = "xmlns:xsi=\"http://www.w3.org/http:STATUS_OK1/XMLSchema-instance\"";
-const string & readonly PLATFORM_MSGS = "platformMsgs:";
-const string & readonly PLATFORM_MSGS_ = "platformMsgs_";
-const string & readonly PLATFORM_CORE = "platformCore:";
-const string & readonly XSI = "xsi:";
-const string & readonly XSI_ = "xsi_";
-const string & readonly SOAP_ENV = "soapenv:";
-const string & readonly SOAP_ENV_ = "soapenv_";
-const string & readonly LIST_ACCT_WITH_COLON = "listAcct:";
-const string & readonly LIST_MRK_WITH_COLON = "listMkt:";
-const string & readonly LIST_REL_WITH_COLON = "listRel:";
-const string & readonly LIST_REL = "listRel";
-const string & readonly EMPTY_STRING = "";
-const string & readonly AMPERSAND = "&";
-const string & readonly ERROR = "ERROR";
-const string & readonly CURRENCY_XSI_TYPE = "listAcct:Currency";
-const string & readonly LIST_ACCT = "listAcct";
-const string & readonly TRAN_SALES = "tranSales";
+const string MESSAGES_NS = "xmlns=\"urn:messages_2020_2.platform.webservices.netsuite.com\"";
+const string CORE_NS = "xmlns:platformCore=\"urn:core_2020_2.platform.webservices.netsuite.com\"";
+const string XSI_NS = "xmlns:xsi=\"http://www.w3.org/http:STATUS_OK1/XMLSchema-instance\"";
+const string PLATFORM_MSGS = "platformMsgs:";
+const string PLATFORM_MSGS_ = "platformMsgs_";
+const string PLATFORM_CORE = "platformCore:";
+const string XSI = "xsi:";
+const string XSI_ = "xsi_";
+const string SOAP_ENV = "soapenv:";
+const string SOAP_ENV_ = "soapenv_";
+const string LIST_ACCT_WITH_COLON = "listAcct:";
+const string LIST_MRK_WITH_COLON = "listMkt:";
+const string LIST_REL_WITH_COLON = "listRel:";
+const string LIST_REL = "listRel";
+const string EMPTY_STRING = "";
+const string AMPERSAND = "&";
+const string ERROR = "ERROR";
+const string CURRENCY_XSI_TYPE = "listAcct:Currency";
+const string LIST_ACCT = "listAcct";
+const string TRAN_SALES = "tranSales";
 
 //Constant values
 public const decimal DEFAULT_ZERO_VALUE = 0.0;
-const string & readonly REQUEST_NEXT_PAGE = "Requesting the next page!";
+const string REQUEST_NEXT_PAGE = "Requesting the next page!";
 
 //Netsuite SOAP endpoint
-const string & readonly NETSUITE_ENDPOINT = "/services/NetSuitePort_2020_2";
+const string NETSUITE_ENDPOINT = "/services/NetSuitePort_2020_2";
+
+//XSDNameSpaces
+const string SCHEDULING_2020_2 = "urn:scheduling_2020_2.activities.webservices.netsuite.com";
+const string FILE_CABINET_2020_2 = "urn:filecabinet_2020_2.documents.webservices.netsuite.com";
+const string COMMUNICATION_2020_2 = "urn:urn:communication_2020_2.general.webservices.netsuite.com";
+const string ACCOUNTING_2020_2 = "urn:accounting_2020_2.lists.webservices.netsuite.com";
+const string EMPLOYEES_2020_2 = "urn:employees_2020_2.lists.webservices.netsuite.com";
+const string MARKETING_2020_2 = "urn:marketing_2020_2.lists.webservices.netsuite.com";
+const string RELATIONSHIPS_2020_2 = "urn:relationships_2020_2.lists.webservices.netsuite.com";
+const string WEBSITE_2020_2 = "urn:website_2020_2.lists.webservices.netsuite.com";
+const string SUPPORT_2020_2 = "urn:support_2020_2.lists.webservices.netsuite.com";
+const string CUSTOMIZATION_2020_2 = "urn:customization_2020_2.setup.webservices.netsuite.com";
+const string FINANCIAL_2020_2 = "urn:financial_2020_2.transactions.webservices.netsuite.com";
+const string SALES_2020_2 = "urn:sales_2020_2.transactions.webservices.netsuite.com";

--- a/netsuite/customer.bal
+++ b/netsuite/customer.bal
@@ -148,7 +148,7 @@ isolated function getCustomerSearchRequestBody(SearchElement[] searchElements) r
     </urn:searchRecord></urn:search></soapenv:Body></soapenv:Envelope>`;
 }
 
-isolated function buildCustomerSearchPayload(NetSuiteConfiguration config,SearchElement[] searchElement) returns 
+isolated function buildCustomerSearchPayload(NetSuiteConfiguration config, SearchElement[] searchElement) returns 
                                             xml|error {
     string requestHeader = check buildXMLPayloadHeader(config);
     string requestBody = getCustomerSearchRequestBody(searchElement);

--- a/netsuite/enums.bal
+++ b/netsuite/enums.bal
@@ -14,6 +14,45 @@
 // specific language governing permissions and limitations
 // under the License.
 
+public enum AdvancedSearchTypes {
+        CALENDAR_EVENT_SEARCH_ADVANCED = "CalendarEventSearchAdvanced",
+        TASK_SEARCH_ADVANCED = "TaskSearchAdvanced",
+        PHONE_CALL_SEARCH_ADVANCED = "PhoneCallSearchAdvanced",
+        FILE_SEARCH_ADVANCED = "FileSearchAdvanced",
+        FOLDER_SEARCH_ADVANCED = "FolderSearchAdvanced",
+        NOTE_SEARCH_ADVANCED = "NoteSearchAdvanced",
+        MESSAGE_SEARCH_ADVANCED = "MessageSearchAdvanced",
+        ITEM_SEARCH_ADVANCED = "ItemSearchAdvanced",
+        ACCOUNT_SEARCH_ADVANCED = "AccountSearchAdvanced",
+        BIN_SEARCH_ADVANCED = "BinSearchAdvanced",
+        CLASSIFICATION_SEARCH_ADVANCED = "ClassificationSearchAdvanced",
+        DEPARTMENT_SEARCH_ADVANCED = "DepartmentSearchAdvanced",
+        LOCATION_SEARCH_ADVANCED = "LocationSearchAdvanced",
+        GIFT_CERTIFICATE_SEARCH_ADVANCED = "GiftCertificateSearchAdvanced",
+        SALES_TAX_ITEM_SEARCH_ADVANCED = "SalesTaxItemSearchAdvanced",
+        SUBSIDIARY_SEARCH_ADVANCED = "SubsidiarySearchAdvanced",
+        EMPLOYEE_SEARCH_ADVANCED = "EmployeeSearchAdvanced",
+        CAMPAIGN_SEARCH_ADVANCED = "CampaignSearchAdvanced",
+        PROMOTION_CODE_SEARCH_ADVANCED = "PromotionCodeSearchAdvanced",
+        CONTACT_SEARCH_ADVANCED = "ContactSearchAdvanced",
+        CUSTOMER_SEARCH_ADVANCED = "CustomerSearchAdvanced",
+        PARTNER_SEARCH_ADVANCED = "PartnerSearchAdvanced",
+        VENDOR_SEARCH_ADVANCED = "VendorSearchAdvanced",
+        ENTITY_GROUP_SEARCH_ADVANCED = "EntityGroupSearchAdvanced",
+        JOB_SEARCH_ADVANCED = "JobSearchAdvanced",
+        SITE_CATEGORY_SEARCH_ADVANCED = "SiteCategorySearchAdvanced",
+        SUPPORT_CASE_SEARCH_ADVANCED = "SupportCaseSearchAdvanced",
+        SOLUTION_SEARCH_ADVANCED = "SolutionSearchAdvanced",
+        TOPIC_SEARCH_ADVANCED = "TopicSearchAdvanced",
+        ISSUE_SEARCH_ADVANCED = "IssueSearchAdvanced",
+        CUSTOM_RECORD_SEARCH_ADVANCED = "CustomRecordSearchAdvanced",
+        TIME_BILL_SEARCH_ADVANCED = "TimeBillSearchAdvanced",
+        BUDGET_SEARCH_ADVANCED = "BudgetSearchAdvanced",
+        ACCOUNTING_TRANSACTION_SEARCH_ADVANCED = "AccountingTransactionSearchAdvanced",
+        OPPORTUNITY_SEARCH_ADVANCED = "OpportunitySearchAdvanced",
+        TRANSACTION_SEARCH_ADVANCED = "TransactionSearchAdvanced"
+}
+
 public enum TransactionType {
     TRANS_ASSEMBLY_BUILD = "_assemblyBuild",
     TRANS_ASSEMBLY_UNBUILD = "_assemblyUnbuild",

--- a/netsuite/responseUtils.bal
+++ b/netsuite/responseUtils.bal
@@ -169,6 +169,41 @@ isolated function formatPayload(http:Response response) returns @tainted xml|err
     return check 'xml:fromString(formattedXMLResponse);
 }
 
+isolated function getSavedSearchIDsResponse(http:Response response) returns @tainted SavedSearchResponse|error {
+    xml payload = check response.getXmlPayload();
+    if (response.statusCode == http:STATUS_OK) {
+        string isSuccessInText = check payload/**/<platformCore:status>.isSuccess;
+        boolean isSuccess = check extractBooleanValueFromXMLOrText(isSuccessInText);
+        if (isSuccess) {
+            int totalRecords  = check 'int:fromString((payload/**/<platformCore:totalRecords>/*).toString());
+            xml recordList = payload/**/<platformCore:recordRefList>/*;
+            SavedSearchReference[] searchReferences = []; 
+            foreach int i in 0 ..< totalRecords {
+                xml recordItem = 'xml:get(recordList, i);
+                searchReferences.push(mapSaveSearchRecords(recordItem));  
+            }
+            return {
+                status: isSuccess,
+                totalReferences: totalRecords,
+                recordRefList: searchReferences
+            };
+        } else {
+            json errorMessage= check xmldata:toJson(payload/**/<statusDetail>/*);
+            fail error(errorMessage.toString());
+        }
+    } else {
+        fail error(payload.toString());
+    }
+}
+
+isolated function mapSaveSearchRecords(xml recordElement) returns SavedSearchReference {
+    return {
+        internalId: extractStringFromXML(recordElement.internalId),
+        scriptId: extractStringFromXML(recordElement.scriptId),
+        name: extractStringFromXML(recordElement/**/<platformCore:name>/*)
+    };
+}
+
 isolated function getServerTimeResponse(http:Response response) returns @tainted string|error {
     xml payload = check response.getXmlPayload();
     if (response.statusCode == http:STATUS_OK) {
@@ -211,6 +246,37 @@ isolated function getXMLRecordListFromSearchResult(http:Response response) retur
         } else {
             json errorMessage= check xmldata:toJson(payload/**/<statusDetail>);
             errorMessage= check xmldata:toJson(payload/**/<soapenv_Fault>/<faultstring>);
+            fail error(errorMessage.toString());
+        }    
+    } else {
+        fail error(payload.toString());
+    }
+}
+
+isolated function getXMLRecordListFromSavedSearchResult(http:Response response) returns @tainted SavedSearchResult|error {
+    xml payload = check response.getXmlPayload();
+    if (response.statusCode == http:STATUS_OK) {
+        xml output  = payload/**/<platformCore:status>;
+        boolean isSuccess = check extractBooleanValueFromXMLOrText(output.isSuccess); 
+        if(isSuccess == true) {
+            int pageIndex = let var value = 'int:fromString((payload/**/<platformCore:pageIndex>/*).toString()) in value is int ? value : 0; 
+            int totalPages = check 'int:fromString((payload/**/<platformCore:totalPages>/*).toString());
+            int totalRecords = check 'int:fromString((payload/**/<platformCore:totalRecords>/*).toString());
+            string searchId = (payload/**/<platformCore:searchId>/*).toString();
+            xml:Element records = <xml:Element> payload/**/<platformCore:searchRowList>;
+            xml children  = 'xml:getChildren(records); 
+            if(children.length() == 0) {
+                fail error(NO_RECORD_FOUND);
+            } 
+            json searchRows = check xmldata:toJson(payload/**/<platformCore:searchRowList>/*, {preserveNamespaces: false});
+            return {
+                recordList: <json[]>searchRows,
+                pageIndex: pageIndex,
+                totalPages: totalPages,
+                searchId: searchId
+            };
+        } else {
+            json errorMessage= check xmldata:toJson(payload/**/<platformCore:statusDetail>/*, {preserveNamespaces: false});
             fail error(errorMessage.toString());
         }    
     } else {

--- a/netsuite/searchUtils.bal
+++ b/netsuite/searchUtils.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/lang.'xml as xmlLib;
 
 isolated  function getSearchElement(SearchElement[] searchElements) returns string{
@@ -75,4 +76,145 @@ isolated function buildSearchMoreWithIdPayload(NetSuiteConfiguration config, int
     string requestHeader = check buildXMLPayloadHeader(config);
     string requestBody = getNextPageRequestElement(pageIndex, searchId);
     return check getSoapPayload(requestHeader, requestBody); 
+}
+
+isolated function buildSavedSearchByIDPayload(NetSuiteConfiguration config, string savedSearchID, string advancedSearchType) returns xml|error {
+    string requestHeader = check buildXMLPayloadHeader(config);
+    string requestBody = check getSaveSearchByIDRequestBody(savedSearchID, advancedSearchType);
+    return check getSoapPayload(requestHeader, requestBody);
+}
+
+isolated function getSaveSearchByIDRequestBody(string savedSearchID, string advancedSearchType) returns string|error {
+    return string `<soapenv:Body><urn:search xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <urn:searchRecord xmlns:q1="${check getSearchAdvancedNS(advancedSearchType)}"
+        xsi:type="q1:${advancedSearchType}" savedSearchId="${savedSearchID}" />
+        </urn:search></soapenv:Body></soapenv:Envelope>`;
+}
+
+isolated function getSavedSearchResult(http:Response response, http:Client httpClient, NetSuiteConfiguration config) returns stream<json, error?>|error {
+    SavedSearchResult resultStatus = check getXMLRecordListFromSavedSearchResult(response);
+    SavedSearchStream instance = check new (httpClient,resultStatus,config);
+    stream<json, error?> finalStream = new (instance);
+    return finalStream;
+}
+
+isolated function getSavedSearchNextPageResult(http:Response response) returns @tainted record {|json[] savedSearchRows; SavedSearchResult status;|}|error {
+    SavedSearchResult resultStatus = check getXMLRecordListFromSavedSearchResult(response);
+    return {savedSearchRows : resultStatus.recordList, status: resultStatus};
+}
+
+isolated function getSearchAdvancedNS(string searchAdvanceType) returns string|error {
+    match searchAdvanceType {
+        CALENDAR_EVENT_SEARCH_ADVANCED => {
+            return SCHEDULING_2020_2;
+        }
+        TASK_SEARCH_ADVANCED => {
+            return SCHEDULING_2020_2;
+        }
+        PHONE_CALL_SEARCH_ADVANCED => {
+            return SCHEDULING_2020_2;
+        }
+        FILE_SEARCH_ADVANCED => {
+            return FILE_CABINET_2020_2;
+        }
+        FOLDER_SEARCH_ADVANCED => {
+            return FILE_CABINET_2020_2;
+        }
+        NOTE_SEARCH_ADVANCED => {
+            return COMMUNICATION_2020_2;
+        }
+        MESSAGE_SEARCH_ADVANCED => {
+            return COMMUNICATION_2020_2;
+        }
+        ITEM_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        ACCOUNT_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        BIN_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        CLASSIFICATION_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        DEPARTMENT_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        LOCATION_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        GIFT_CERTIFICATE_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        SALES_TAX_ITEM_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        SUBSIDIARY_SEARCH_ADVANCED => {
+            return ACCOUNTING_2020_2;
+        }
+        EMPLOYEE_SEARCH_ADVANCED => {
+            return EMPLOYEES_2020_2;
+        }
+        CAMPAIGN_SEARCH_ADVANCED => {
+            return MARKETING_2020_2;
+        }
+        PROMOTION_CODE_SEARCH_ADVANCED => {
+            return MARKETING_2020_2;
+        }
+        CONTACT_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        CUSTOMER_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        PARTNER_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        VENDOR_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        ENTITY_GROUP_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        JOB_SEARCH_ADVANCED => {
+            return RELATIONSHIPS_2020_2;
+        }
+        SITE_CATEGORY_SEARCH_ADVANCED => {
+            return WEBSITE_2020_2;
+        }
+        SUPPORT_CASE_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        SOLUTION_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        TOPIC_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        ISSUE_SEARCH_ADVANCED => {
+            return SUPPORT_2020_2;
+        }
+        CUSTOM_RECORD_SEARCH_ADVANCED => {
+            return CUSTOMIZATION_2020_2;
+        }
+        TIME_BILL_SEARCH_ADVANCED => {
+            return EMPLOYEES_2020_2;
+        }
+        BUDGET_SEARCH_ADVANCED => {
+            return FINANCIAL_2020_2;
+        }
+        ACCOUNTING_TRANSACTION_SEARCH_ADVANCED => {
+            return SALES_2020_2;
+        }
+        OPPORTUNITY_SEARCH_ADVANCED => {
+            return SALES_2020_2;
+        }
+        TRANSACTION_SEARCH_ADVANCED => {
+            return SALES_2020_2;
+        }
+        _ => {
+            fail error(NO_TYPE_MATCHED);
+        }
+    }
 }

--- a/netsuite/streams.bal
+++ b/netsuite/streams.bal
@@ -189,3 +189,45 @@ class ContactStream {
         return newPage.contacts;
     }
 }
+
+class SavedSearchStream {
+    private json[] savedSearchRowEntries = [];
+    int index = 0;
+    private final http:Client httpClient;
+    int totalPages;
+    int currentPage;
+    string searchId;
+    NetSuiteConfiguration config;
+
+    isolated function  init(http:Client httpClient, SavedSearchResult resultStatus, NetSuiteConfiguration config) 
+                            returns @tainted error? {
+        self.httpClient = httpClient;
+        self.savedSearchRowEntries = resultStatus.recordList;
+        self.totalPages = resultStatus.totalPages;
+        self.currentPage = resultStatus.pageIndex;
+        self.searchId = resultStatus.searchId;
+        self.config = config;
+    }
+
+    public isolated function next() returns @tainted record {| json value; |}|error? {
+        if(self.index < self.savedSearchRowEntries.length()) {
+            record {| json value; |} singleRecord = {value: self.savedSearchRowEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }else if (self.totalPages != self.currentPage ) {
+            self.index = 0;
+            self.savedSearchRowEntries = check self.fetchNextSavedSearchResults();
+            record {| json value; |} singleRecord = {value: self.savedSearchRowEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchNextSavedSearchResults() returns @tainted json[]|error {
+        xml payload = check buildSearchMoreWithIdPayload(self.config, self.currentPage + 1, self.searchId);
+        http:Response response = check sendRequest(self.httpClient, SEARCH_MORE_WITH_ID, payload);
+        record {|json[] savedSearchRows; SavedSearchResult status;|} newPage = check getSavedSearchNextPageResult(response);
+        self.currentPage=newPage.status.pageIndex;
+        return newPage.savedSearchRows;
+    }
+}

--- a/netsuite/tests/test.bal
+++ b/netsuite/tests/test.bal
@@ -710,6 +710,37 @@ function testGetServerTime() {
     }
 }
 
+string savedSearchID = "";
+@test:Config {enable: true}
+function testGetSavedSearchIds() {
+    log:printInfo("testGetSavedSearchIds");
+    SavedSearchResponse|error output = netsuiteClient->getSavedSearchIDs("vendor");
+    if (output is SavedSearchResponse) {
+        savedSearchID = output.recordRefList[0].internalId;
+    } else {
+        test:assertFalse(true, output.toString());
+    }
+}
+
+
+@test:Config {enable: true, dependsOn: [testGetSavedSearchIds]}
+function testPerformSavedSearchById() {
+    log:printInfo("testPerformSavedSearchById");
+    var output = netsuiteClient->performSavedSearchById(savedSearchID, "VendorSearchAdvanced");
+    if (output is stream<json, error?>) {
+        int index = 0;
+        error? e = output.forEach(function (json queryResult) {
+            index = index + 1;
+            if(index == 1) {
+                log:printInfo(queryResult.toString());
+            }
+        });
+        log:printInfo("Total count of records in SavedSearchResults : " +  index.toString()); 
+    } else {
+         test:assertFalse(true, output.toString());
+    }
+}
+
 @test:Config {enable: true, dependsOn: [testAddNewCustomerRecord]} 
 function testCustomerRecordGetOperation() {
     log:printInfo("testCustomerRecordGetOperation");


### PR DESCRIPTION
## Purpose
> Add saved search operations to the connector.
Fixes https://github.com/wso2-enterprise/choreo/issues/7788

## Goals
> Improve the connector based on feature requests

## Approach
1. Added getSavedSearchIDs operation
2. Added performSavedSearchById operation with stream support.
3. Updated docs

## Automation tests
 - Unit tests 
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina Swan Lake Beta3

## Learning
> https://www.netsuite.com/portal/developers/resources/suitetalk-documentation.shtml