### PR TITLE
Fix CURL command in daily build fail notification

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,24 +17,6 @@ jobs:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2
 
-            # Set up Java Environment
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
-              with:
-                java-version: 11
-            
-            # Grant execute permission to the gradlew script
-            - name: Grant execute permission for gradlew
-              run: chmod +x gradlew
-
-            # Build the project with Gradle
-            - name: Build with Gradle
-              env:
-                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
-              run: |
-                ./gradlew build
             # Build the ballerina project
             - name: Ballerina Build
               uses: ballerina-platform/ballerina-action/@nightly
@@ -54,10 +36,10 @@ jobs:
             - name: Notify failure
               if: ${{ failure() }}
               run: |
-                curl -X POST
-                'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches'\
-                -H 'Accept: application/vnd.github.v3+json'\
-                -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}'\
+                curl -X POST \
+                'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches' \
+                -H 'Accept: application/vnd.github.v3+json' \
+                -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
                 --data "{
                   \"event_type\": \"notify-connector-failure\",
                   \"client_payload\": {


### PR DESCRIPTION
# Description
- Fix syntax issue in CURL command used in daily build failure notification.
- Remove unneccessary gradle steps 

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 