### PR TITLE
Remove ballerinaLang version since it is not used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ plugins {
     id "net.researchgate.release" version "2.8.0"
 }
 
-ext.ballerinaLangVersion = project.ballerinaLangVersion
-
 allprojects {
     group = project.group
     version = project.version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.caching=true
 group=org.ballerinalang.netsuite
 version=2.2.0
-ballerinaLangVersion=2.0.0-beta.6


### PR DESCRIPTION
# Purpose
- Remove ballerinaLang version since it is not used

NOTE:  ballerinaLang version is needed only if a connector has java-wrapper.
 
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
